### PR TITLE
fix broken build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ FROM python-base As stage1
 
 # install git
 RUN set -eux; apt-get update; apt-get install -y --no-install-recommends \
-    ca-certificates git; \
+    ca-certificates git gcc python3-dev; \
   rm -rf /var/lib/apt/lists/*
 
 # prepare clone
@@ -47,9 +47,9 @@ RUN set -eux; \
     for i in $PLGN_CONFLICT; do rm -rf plugins/$i; done; \
   fi; \
 # necessary to run smarthome.py
-  python -m pip install --no-cache-dir ruamel.yaml; \
+python -m pip install --no-cache-dir "ruamel.yaml<=0.16.8"; \
 # create requirement files
-  python3 bin/smarthome.py --stop
+  python3 bin/smarthome.py --stop || true
 
 ### Build Stage 3 - build requirements for smarthomNG ###########################
 FROM python-base As stage3


### PR DESCRIPTION
docker build failed for me on Linux/x86_64 and Linux/arm64 machines.
One reason was missing gcc and python-dev packages/header files.
Once that was fixed, pip complained about ruamel.yaml being too new so I limited it to 0.16.8 (this is, what pip requested as latest version)

Most tricky part without a real solution is that 'smarthome.py --stop' exited with an error return code, killing the docker build. There is an empty error message in the logs (see below). Ignoring the error gives a working requirements.txt anyway, thats what the '|| true' does.

Log snipped follows:
#10 [stage2 2/2] RUN set -eux;   if [ "appletv hue2" ]; then     for i in appletv hue2; do rm -rf plugins/$i; done;   fi; python -m pip install --no-cache-dir "ruamel.yaml<=0.16.8";   python3 bin/smarthome.py --stop || true
#10 4.903 Collecting ruamel.yaml<=0.16.8
#10 5.034   Downloading ruamel.yaml-0.16.7-py2.py3-none-any.whl (123 kB)
#10 5.074      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 124.0/124.0 kB 3.9 MB/s eta 0:00:00
#10 5.162 Installing collected packages: ruamel.yaml
#10 5.306 Successfully installed ruamel.yaml-0.16.7
#10 5.310 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
#10 5.586 
#10 5.586 [notice] A new release of pip is available: 23.0.1 -> 23.2.1
#10 5.586 [notice] To update, run: pip install --upgrade pip
#10 5.731 + python3 bin/smarthome.py --stop
#10 6.083 > using PIP command: '/usr/local/bin/pip3'
#10 14.09 SmartHomeNG should not run as root
#10 14.09 
#10 14.09 test_requirements: 'ephem' not installed. Minimum v3.7 needed
#10 14.09 test_requirements: 'holidays' not installed. Minimum v0.9.11 needed
#10 14.09 test_requirements: 'iowait' not installed, any version needed
#10 14.09 test_requirements: 'portalocker' not installed, any version needed
#10 14.09 test_requirements: 'psutil' not installed, any version needed
#10 14.09 test_requirements: 'python-dateutil' not installed. Minimum v2.5.3 needed
#10 14.09 test_requirements: 'requests' not installed. Minimum v2.20.0 needed
#10 14.09 test_requirements: 'xmltodict' not installed, any version needed
#10 14.09 
#10 14.09 Installing core requirements for the current user, please wait...
#10 14.09 python_bin_path=/usr/local/bin
#10 14.09 
#10 14.09 ERROR:
#10 14.09 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
#10 14.09 
#10 14.09 [notice] A new release of pip is available: 23.0.1 -> 23.2.1
#10 14.09 [notice] To update, run: pip install --upgrade pip
#10 14.09 
#10 14.09 ERROR: Unable to install core requirements
#10 14.09 Use the commandline option --pip3_command to specify the path to the command
#10 14.09 
#10 14.12 + true
#10 DONE 14.3s

#12 [stage3 1/2] COPY --from=stage2 /usr/local/smarthome/requirements/all.txt /requirements.txt
#12 DONE 0.1s
